### PR TITLE
Create ldap-mode.el

### DIFF
--- a/recipes/ldap-mode.el
+++ b/recipes/ldap-mode.el
@@ -1,0 +1,1 @@
+(ldap-mode :repo "emacsmirror/ldap-mode" :fetcher github)


### PR DESCRIPTION
Official is at http://www.loveshack.ukfsn.org/emacs/ldap-mode.el, however I've chosen emacsmirror, since it's more probably to persist.
